### PR TITLE
Fix usage example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ struct Person {
 }
 
 // Reflects the instance properties of type `Person`
-let properties = try properties(Person)
+let props = try properties(Person.self)
 
 var person = Person(firstName: "John", lastName: "Smith", age: 35)
 


### PR DESCRIPTION
The first usage example in the readme fails to compile under Swift 3.0.2 on this line:

    let properties = try properties(Person)

with one error and one warning:

    error: variable used within its own initial value
    warning: missing '.self' for reference to metatype of type 'Person'

This change fixes it.