### PR TITLE
Reflection.properties returns different results on first and following calls

### DIFF
--- a/Sources/Reflection/Metadata+Class.swift
+++ b/Sources/Reflection/Metadata+Class.swift
@@ -14,7 +14,7 @@ extension Metadata {
         }
         
         func properties() throws -> [Property.Description] {
-            let properties = try fetchAndSaveProperties(nominalType: self, hashedType: HashedType(pointer))
+            let properties = try propertiesForNominalType(self)
             guard let superclass = superclass, String(describing: unsafeBitCast(superclass.pointer, to: Any.Type.self)) != "SwiftObject" else {
                 return properties
             }

--- a/Sources/Reflection/Properties.swift
+++ b/Sources/Reflection/Properties.swift
@@ -49,25 +49,21 @@ private func nextProperty(description: Property.Description, storage: UnsafeRawP
 public func properties(_ type: Any.Type) throws -> [Property.Description] {
     let hashedType = HashedType(type)
     if let properties = cachedProperties[hashedType] {
-        // When cached, only nominal type properties are returned
         return properties
     } else if let nominalType = Metadata.Struct(type: type) {
-        return try fetchAndSaveProperties(nominalType: nominalType, hashedType: hashedType)
+        let properties = try propertiesForNominalType(nominalType)
+        cachedProperties[hashedType] = properties
+        return properties
     } else if let nominalType = Metadata.Class(type: type) {
-        // This will return all properties (nominal and super), but only cache nominal
-        return try nominalType.properties()
+        let properties = try nominalType.properties()
+        cachedProperties[hashedType] = properties
+        return properties
     } else {
         throw ReflectionError.notStruct(type: type)
     }
 }
 
-func fetchAndSaveProperties<T : NominalType>(nominalType: T, hashedType: HashedType) throws -> [Property.Description] {
-    let properties = try propertiesForNominalType(nominalType)
-    cachedProperties[hashedType] = properties
-    return properties
-}
-
-private func propertiesForNominalType<T : NominalType>(_ type: T) throws -> [Property.Description] {
+internal func propertiesForNominalType<T : NominalType>(_ type: T) throws -> [Property.Description] {
     guard type.nominalTypeDescriptor.numberOfFields != 0 else { return [] }
     guard let fieldTypes = type.fieldTypes, let fieldOffsets = type.fieldOffsets else {
         throw ReflectionError.unexpected

--- a/Sources/Reflection/Properties.swift
+++ b/Sources/Reflection/Properties.swift
@@ -49,10 +49,12 @@ private func nextProperty(description: Property.Description, storage: UnsafeRawP
 public func properties(_ type: Any.Type) throws -> [Property.Description] {
     let hashedType = HashedType(type)
     if let properties = cachedProperties[hashedType] {
+        // When cached, only nominal type properties are returned
         return properties
     } else if let nominalType = Metadata.Struct(type: type) {
         return try fetchAndSaveProperties(nominalType: nominalType, hashedType: hashedType)
     } else if let nominalType = Metadata.Class(type: type) {
+        // This will return all properties (nominal and super), but only cache nominal
         return try nominalType.properties()
     } else {
         throw ReflectionError.notStruct(type: type)


### PR DESCRIPTION
Sorry for doing it like this, issues are disabled.

So using `Reflection.properties` or `Reflection.get` caches the results, but only the result of the top class are cached. So the first call returns all properties in the class hierarchy, but the second call only return properties of the top class. It should always return the same thing, my preference being all the properties.