### PR TITLE
Fix for setting value on a class object thats casted as an Any

### DIFF
--- a/Sources/Reflection/Set.swift
+++ b/Sources/Reflection/Set.swift
@@ -1,7 +1,7 @@
 /// Set value for key of an instance
-public func set(_ value: Any, key: String, for instance: inout Any, instanceType: Any.Type? = nil) throws {
-    let type = instanceType ?? type(of: instance)
-    try property(type: type(of: instance), key: key).write(value, to: mutableStorage(instance: &instance, type: type))
+public func set(_ value: Any, key: String, for instance: inout Any) throws {
+    let type = type(of: instance)
+    try property(type: type, key: key).write(value, to: mutableStorage(instance: &instance, type: type))
 }
 
 /// Set value for key of an instance

--- a/Sources/Reflection/Set.swift
+++ b/Sources/Reflection/Set.swift
@@ -14,7 +14,7 @@ public func set<T>(_ value: Any, key: String, for instance: inout T) throws {
     try property(type: T.self, key: key).write(value, to: mutableStorage(instance: &instance))
 }
 
-/// Set value for specified type. For cases when the object is casted as any but Type is known
+/// Set value for specified type. For cases when the object is casted as Any but Type is known
 public func set<T>(_ value: Any, key: String, type: Any.Type, for instance: inout T) throws {
     try property(type: type, key: key).write(value, to: mutableStorage(instance: &instance, type: type))
 }

--- a/Sources/Reflection/Set.swift
+++ b/Sources/Reflection/Set.swift
@@ -15,7 +15,7 @@ public func set<T>(_ value: Any, key: String, for instance: inout T) throws {
 }
 
 /// Set value for specified type. For cases when the object is casted as any but Type is known
-public func set<T>(_ value: Any, key: String, for instance: inout T, type: Any.Type) throws {
+public func set<T>(_ value: Any, key: String, type: Any.Type, for instance: inout T) throws {
     try property(type: type, key: key).write(value, to: mutableStorage(instance: &instance, type: type))
 }
 

--- a/Sources/Reflection/Set.swift
+++ b/Sources/Reflection/Set.swift
@@ -10,13 +10,8 @@ public func set(_ value: Any, key: String, for instance: AnyObject) throws {
 }
 
 /// Set value for key of an instance
-public func set<T>(_ value: Any, key: String, for instance: inout T) throws {
-    try property(type: T.self, key: key).write(value, to: mutableStorage(instance: &instance))
-}
-
-/// Set value for specified type. For cases when the object is casted as Any but Type is known
-public func set<T>(_ value: Any, key: String, type: Any.Type, for instance: inout T) throws {
-    try property(type: type, key: key).write(value, to: mutableStorage(instance: &instance, type: type))
+public func set<T>(_ value: Any, key: String, for instance: inout T, instanceType: Any.Type = T.self) throws {
+    try property(type: instanceType, key: key).write(value, to: mutableStorage(instance: &instance, type: instanceType))
 }
 
 private func property(type: Any.Type, key: String) throws -> Property.Description {

--- a/Sources/Reflection/Set.swift
+++ b/Sources/Reflection/Set.swift
@@ -1,6 +1,7 @@
 /// Set value for key of an instance
-public func set(_ value: Any, key: String, for instance: inout Any) throws {
-    try property(type: type(of: instance), key: key).write(value, to: mutableStorage(instance: &instance))
+public func set(_ value: Any, key: String, for instance: inout Any, instanceType: Any.Type? = nil) throws {
+    let type = instanceType ?? type(of: instance)
+    try property(type: type(of: instance), key: key).write(value, to: mutableStorage(instance: &instance, type: type))
 }
 
 /// Set value for key of an instance
@@ -10,8 +11,8 @@ public func set(_ value: Any, key: String, for instance: AnyObject) throws {
 }
 
 /// Set value for key of an instance
-public func set<T>(_ value: Any, key: String, for instance: inout T, instanceType: Any.Type = T.self) throws {
-    try property(type: instanceType, key: key).write(value, to: mutableStorage(instance: &instance, type: instanceType))
+public func set<T>(_ value: Any, key: String, for instance: inout T) throws {
+    try property(type: T.self, key: key).write(value, to: mutableStorage(instance: &instance))
 }
 
 private func property(type: Any.Type, key: String) throws -> Property.Description {

--- a/Sources/Reflection/Set.swift
+++ b/Sources/Reflection/Set.swift
@@ -14,6 +14,11 @@ public func set<T>(_ value: Any, key: String, for instance: inout T) throws {
     try property(type: T.self, key: key).write(value, to: mutableStorage(instance: &instance))
 }
 
+/// Set value for specified type. For cases when the object is casted as any but Type is known
+public func set<T>(_ value: Any, key: String, for instance: inout T, type: Any.Type) throws {
+    try property(type: type, key: key).write(value, to: mutableStorage(instance: &instance, type: type))
+}
+
 private func property(type: Any.Type, key: String) throws -> Property.Description {
     guard let property = try properties(type).first(where: { $0.key == key }) else { throw ReflectionError.instanceHasNoKey(type: type, key: key) }
     return property

--- a/Sources/Reflection/Storage.swift
+++ b/Sources/Reflection/Storage.swift
@@ -31,4 +31,3 @@ func storage<T>(instance: inout T, type: Any.Type) -> UnsafeRawPointer {
         }
     }
 }
-

--- a/Sources/Reflection/Storage.swift
+++ b/Sources/Reflection/Storage.swift
@@ -16,7 +16,7 @@ func mutableStorage<T>(instance: inout T) -> UnsafeMutableRawPointer {
 
 func mutableStorage<T>(instance: inout T, type: Any.Type) -> UnsafeMutableRawPointer {
     return UnsafeMutableRawPointer(mutating: storage(instance: &instance, type: type))
-}
+}   
 
 func storage<T>(instance: inout T) -> UnsafeRawPointer {
     return storage(instance: &instance, type: type(of: instance))

--- a/Sources/Reflection/Storage.swift
+++ b/Sources/Reflection/Storage.swift
@@ -11,15 +11,24 @@ extension AnyExtensions {
 }
 
 func mutableStorage<T>(instance: inout T) -> UnsafeMutableRawPointer {
-    return UnsafeMutableRawPointer(mutating: storage(instance: &instance))
+    return mutableStorage(instance: &instance, type: type(of: instance))
+}
+
+func mutableStorage<T>(instance: inout T, type: Any.Type) -> UnsafeMutableRawPointer {
+    return UnsafeMutableRawPointer(mutating: storage(instance: &instance, type: type))
 }
 
 func storage<T>(instance: inout T) -> UnsafeRawPointer {
+    return storage(instance: &instance, type: type(of: instance))
+}
+
+func storage<T>(instance: inout T, type: Any.Type) -> UnsafeRawPointer {
     return withUnsafePointer(to: &instance) { pointer in
-        if type(of: instance) is AnyClass {
+        if type is AnyClass {
             return UnsafeRawPointer(bitPattern: UnsafePointer<Int>(pointer).pointee)!
         } else {
             return UnsafeRawPointer(pointer)
         }
     }
 }
+


### PR DESCRIPTION
I ran into an issue setting a value on an object that was casted as an Any. From what I can tell the problem was in the storage. The type of the instance was not being recognized as AnyClass even though it is. What is happening is once it is passed to `storage<T>` casted as an `Any` the method `type(of:)` no longer returns the correct type of the instance, it returns `Any` due to the generics. Would like to hear your input.

Not sure if this is the best way to fix it. Another solution would be to remove the generics but that may break other things. This is less invasive